### PR TITLE
feat: batch endpoint для courses по IDs

### DIFF
--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -30,22 +30,17 @@ export default function useDashboardData() {
           auth: true,
         })
         const safeEnrollments = normalizeCollection(enrollmentsData)
-        const enriched = await Promise.all(
-          safeEnrollments.map(async (enrollment) => {
-            try {
-              const course = await apiRequest(`/courses/${enrollment.course_id}`, {
-                method: 'GET',
-                auth: false,
-              })
-              return { ...enrollment, course, courseError: null }
-            } catch (enrollError) {
-              const message = enrollError?.status === 404
-                ? 'Курс удален или скрыт'
-                : 'Курс временно недоступен'
-              return { ...enrollment, course: null, courseError: message }
-            }
-          }),
-        )
+        const courseIds = safeEnrollments.map(e => e.course_id)
+        const batch = await apiRequest('/courses/by-ids', {
+          method: 'POST',
+          body: { course_ids: courseIds },
+        })
+        const coursesMap = new Map(batch.found.map(c => [c.id, c]))
+        const enriched = safeEnrollments.map(enrollment => ({
+          ...enrollment,
+          course: coursesMap.get(enrollment.course_id) || null,
+          courseError: coursesMap.has(enrollment.course_id) ? null : 'Курс удален или скрыт',
+        }))
         if (mounted) {
           setEnrollments(enriched)
         }

--- a/infra/api-gateway/config/settings/course_endpoints.json
+++ b/infra/api-gateway/config/settings/course_endpoints.json
@@ -46,6 +46,12 @@
         },
         {
             "type": "unprotected",
+            "endpoint_path": "/courses/by-ids",
+            "method": "POST",
+            "backend_pattern": "/courses/by-ids"
+        },
+        {
+            "type": "unprotected",
             "endpoint_path": "/courses/{course_id}",
             "method": "GET",
             "backend_pattern": "/courses/{course_id}"

--- a/microservices/course/app/routers/courses.py
+++ b/microservices/course/app/routers/courses.py
@@ -37,6 +37,24 @@ async def list_courses(
     return {"items": items, "total": total, "skip": skip, "limit": limit}
 
 
+@router.post(
+    "/by-ids",
+    response_model=sch_courses.CourseBatchResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Получить курсы по списку id",
+)
+async def get_courses_by_ids(
+    data: sch_courses.CourseBatchRequest,
+    course_service: CourseService = Depends(get_course_service),
+) -> sch_courses.CourseBatchResponse:
+    courses = await course_service.get_courses_by_ids(course_ids=data.course_ids)
+
+    found_ids = {course.id for course in courses}
+    missing_ids = [uid for uid in data.course_ids if uid not in found_ids]
+
+    return sch_courses.CourseBatchResponse(found=courses, missing=missing_ids)
+
+
 @router.get(
     "/{course_id}",
     response_model=sch_courses.CourseRead,

--- a/microservices/course/app/schemas/courses.py
+++ b/microservices/course/app/schemas/courses.py
@@ -46,6 +46,29 @@ class CourseRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class CourseBatchRequest(BaseModel):
+    course_ids: Annotated[
+        list[UUID],
+        Field(
+            ...,
+            min_length=1,
+            max_length=100,
+            description="Список ID курсов для получения информации о них",
+        ),
+    ]
+
+
+class CourseBatchResponse(BaseModel):
+    found: Annotated[
+        list[CourseRead],
+        Field(description="Список найденных курсов"),
+    ] = []
+    missing: Annotated[
+        list[UUID],
+        Field(description="Список ID курсов, для которых не была найдена информация"),
+    ] = []
+
+
 class SectionCreate(BaseModel):
     title: Annotated[str, Field(..., min_length=1, max_length=255)]
     position: int | None = None

--- a/microservices/course/app/services/courses.py
+++ b/microservices/course/app/services/courses.py
@@ -45,6 +45,14 @@ class CourseService:
 
         return result.scalars().all(), int(total or 0)
 
+    async def get_courses_by_ids(self, course_ids: list[UUID]) -> Sequence[Course]:
+        """Возвращает курсы по списку id."""
+        result = await self.session.execute(
+            select(Course).where(Course.id.in_(course_ids))
+        )
+
+        return result.scalars().all()
+
     async def get_course_or_404(self, course_id: UUID) -> Course:
         """Возвращает курс по id или 404."""
         result = await self.session.execute(
@@ -188,7 +196,9 @@ class CourseService:
         await self.get_course_or_404(course_id=course_id)
 
         total_query = (
-            select(func.count()).select_from(Section).where(Section.course_id == course_id)
+            select(func.count())
+            .select_from(Section)
+            .where(Section.course_id == course_id)
         )
         total = await self.session.scalar(total_query)
 

--- a/microservices/course/tests/api/test_courses.py
+++ b/microservices/course/tests/api/test_courses.py
@@ -33,6 +33,82 @@ async def test_get_course_not_found(async_client: AsyncClient):
     assert resp.status_code == 404
 
 
+async def test_get_courses_by_ids(async_client: AsyncClient, course_factory):
+    course_a = await course_factory()
+    course_b = await course_factory()
+
+    resp = await async_client.post(
+        "/courses/by-ids",
+        json={"course_ids": [str(course_a.id), str(course_b.id), str(uuid4())]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["found"]) == 2
+    assert len(body["missing"]) == 1
+    assert set(item["id"] for item in body["found"]) == {
+        str(course_a.id),
+        str(course_b.id),
+    }
+
+
+async def test_get_courses_by_ids_empty_list(async_client: AsyncClient):
+    resp = await async_client.post(
+        "/courses/by-ids",
+        json={"course_ids": []},
+    )
+    assert resp.status_code == 422
+
+
+async def test_get_courses_by_ids_all_missing(async_client: AsyncClient):
+    fake_ids = [str(uuid4()), str(uuid4())]
+    resp = await async_client.post(
+        "/courses/by-ids",
+        json={"course_ids": fake_ids},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["found"] == []
+    assert set(body["missing"]) == set(fake_ids)
+
+
+async def test_get_courses_by_ids_limit_exceeded(
+    async_client: AsyncClient,
+):
+    fake_ids = [str(uuid4()) for _ in range(101)]
+    resp = await async_client.post(
+        "/courses/by-ids",
+        json={"course_ids": fake_ids},
+    )
+    assert resp.status_code == 422
+
+
+async def test_get_courses_by_ids_invalid_uuid(
+    async_client: AsyncClient,
+):
+    resp = await async_client.post(
+        "/courses/by-ids",
+        json={"course_ids": ["not-a-uuid"]},
+    )
+    assert resp.status_code == 422
+
+
+async def test_get_courses_by_ids_duplicates(
+    async_client: AsyncClient,
+    course_factory,
+):
+    course = await course_factory()
+    course_id = str(course.id)
+
+    resp = await async_client.post(
+        "/courses/by-ids",
+        json={"course_ids": [course_id, course_id, course_id]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["found"]) == 1
+    assert body["missing"] == []
+
+
 async def test_create_course_unauthorized(
     async_client: AsyncClient,
     course_create_data_factory,
@@ -448,9 +524,7 @@ async def test_delete_section_not_found(
     user_owner,
 ):
     course = await course_factory(author_id=user_owner["id"])
-    resp = await auth_client_owner.delete(
-        f"/courses/{course.id}/sections/{uuid4()}"
-    )
+    resp = await auth_client_owner.delete(f"/courses/{course.id}/sections/{uuid4()}")
     assert resp.status_code == 404
 
 
@@ -498,9 +572,7 @@ async def test_list_lessons_pagination_total(
 
 
 async def test_list_lessons_course_not_found(async_client: AsyncClient):
-    resp = await async_client.get(
-        f"/courses/{uuid4()}/sections/{uuid4()}/lessons"
-    )
+    resp = await async_client.get(f"/courses/{uuid4()}/sections/{uuid4()}/lessons")
     assert resp.status_code == 404
 
 


### PR DESCRIPTION
## Summary

- Added `POST /courses/by-ids` endpoint for batch course retrieval
- Resolved N+1 problem in `useDashboardData.js` (N requests → 1)
- 6 tests covering all scenarios

## Changes

### Backend
- `microservices/course/app/schemas/courses.py` — `CourseBatchRequest` and `CourseBatchResponse`
- `microservices/course/app/services/courses.py` — `get_courses_by_ids`
- `microservices/course/app/routers/courses.py` — `POST /by-ids`
- `infra/api-gateway/config/settings/course_endpoints.json` — route

### Frontend
- `frontend/src/hooks/useDashboardData.js` — batch request instead of loop

### Tests
- `microservices/course/tests/api/test_courses.py` — 6 tests

## Commits

| # | Commit |
|---|--------|
| 1 | `feat(course): add CourseBatchRequest and CourseBatchResponse schemas` |
| 2 | `feat(course): add get_courses_by_ids service method` |
| 3 | `feat(course): add POST /courses/by-ids batch endpoint` |
| 4 | `feat(gateway): add route for POST /courses/by-ids` |
| 5 | `feat(frontend): use batch endpoint in useDashboardData` |
| 6 | `test(course): add batch endpoint tests` |
